### PR TITLE
feat(oci): add oci logging integrations

### DIFF
--- a/examples/modules/cloud-integrations/oci/logs-integration/locals.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/locals.tf
@@ -1,0 +1,27 @@
+locals {
+  freeform_tags = {
+    newrelic-terraform = "true"
+  }
+
+  # VCN Constants
+  vcn_name          = "newrelic-vcn"
+  nat_gateway       = "newrelic-natgateway"
+  service_gateway   = "newrelic-servicegateway"
+  internet_gateway  = "newrelic-internetgateway"
+  subnet            = "newrelic-private-subnet"
+
+  # Function App Constants
+  function_app_name  = "${var.newrelic_logging_prefix}-${var.region}-logs-function-app"
+  function_app_shape = "GENERIC_X86"
+  client_ttl         = 30
+
+  # Function Constants
+  function_name        = "${var.newrelic_logging_prefix}-${var.region}-logs-function"
+  memory_in_mbs        = "128"
+  image_version_latest = "latest" # todo: to modify post version decision
+  image_url            = "${var.region}.ocir.io/idfmbxeaoavl/newrelic-log-container/log-forwarder:${local.image_version_latest}" #todo: change once prod ocir is ready
+
+  # Connector Hub Constants
+  batch_size_in_kbs = 100 # todo: change batch size
+  batch_time_in_sec = 60
+}

--- a/examples/modules/cloud-integrations/oci/logs-integration/locals.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/locals.tf
@@ -3,16 +3,18 @@ locals {
     newrelic-terraform = "true"
   }
 
+  terraform_suffix = "terraform"
+
   # VCN Constants
-  vcn_name          = "newrelic-${var.newrelic_logging_prefix}-${var.region}-vcn"
-  nat_gateway       = "newrelic-${var.newrelic_logging_prefix}-${var.region}-natgateway"
-  service_gateway   = "newrelic-${var.newrelic_logging_prefix}-${var.region}-servicegateway"
-  internet_gateway  = "newrelic-${var.newrelic_logging_prefix}-${var.region}-internetgateway"
+  vcn_name          = "newrelic-${var.newrelic_logging_identifier}-${var.region}-vcn-${local.terraform_suffix}"
+  nat_gateway       = "newrelic-${var.newrelic_logging_identifier}-${var.region}-natgateway-${local.terraform_suffix}"
+  service_gateway   = "newrelic-${var.newrelic_logging_identifier}-${var.region}-servicegateway-${local.terraform_suffix}"
+  internet_gateway  = "newrelic-${var.newrelic_logging_identifier}-${var.region}-internetgateway-${local.terraform_suffix}"
   vcn_dns_label     = "nrlogging"
   vcn_cidr_block    = "10.0.0.0/16"
 
   # Subnet Constants
-  subnet               = "newrelic-${var.newrelic_logging_prefix}-${var.region}-private-subnet"
+  subnet               = "newrelic-${var.newrelic_logging_identifier}-${var.region}-private-subnet-${local.terraform_suffix}"
   subnet_cidr_block    = "10.0.0.0/16"
   subnet_type          = "private"
 
@@ -20,15 +22,13 @@ locals {
   internet_destination = "0.0.0.0/0"
 
   # Function App Constants
-  function_app_name  = "newrelic-${var.newrelic_logging_prefix}-${var.region}-logs-function-app"
+  function_app_name  = "newrelic-${var.newrelic_logging_identifier}-${var.region}-logs-function-app-${local.terraform_suffix}"
   function_app_shape = "GENERIC_X86"
   client_ttl         = 30
 
   # Function Constants
-  function_name        = "newrelic-${var.newrelic_logging_prefix}-${var.region}-logs-function"
-  memory_in_mbs        = "128"
-
-  # Connector Hub Constants
-  batch_size_in_kbs = 6000
-  batch_time_in_sec = 60
+  function_name                 = "newrelic-${var.newrelic_logging_identifier}-${var.region}-logs-function-${local.terraform_suffix}"
+  function_memory_in_mbs        = "128"
+  time_out_in_seconds           = 300
+  image_url                     = "${var.region}/idfmbxeaoavl/newrelic-log-container/log-forwarder:${var.image_version}"
 }

--- a/examples/modules/cloud-integrations/oci/logs-integration/locals.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/locals.tf
@@ -4,24 +4,31 @@ locals {
   }
 
   # VCN Constants
-  vcn_name          = "newrelic-vcn"
-  nat_gateway       = "newrelic-natgateway"
-  service_gateway   = "newrelic-servicegateway"
-  internet_gateway  = "newrelic-internetgateway"
-  subnet            = "newrelic-private-subnet"
+  vcn_name          = "newrelic-${var.newrelic_logging_prefix}-${var.region}-vcn"
+  nat_gateway       = "newrelic-${var.newrelic_logging_prefix}-${var.region}-natgateway"
+  service_gateway   = "newrelic-${var.newrelic_logging_prefix}-${var.region}-servicegateway"
+  internet_gateway  = "newrelic-${var.newrelic_logging_prefix}-${var.region}-internetgateway"
+  vcn_dns_label     = "nrlogging"
+  vcn_cidr_block    = "10.0.0.0/16"
+
+  # Subnet Constants
+  subnet               = "newrelic-${var.newrelic_logging_prefix}-${var.region}-private-subnet"
+  subnet_cidr_block    = "10.0.0.0/16"
+  subnet_type          = "private"
+
+  # Route Table Constants
+  internet_destination = "0.0.0.0/0"
 
   # Function App Constants
-  function_app_name  = "${var.newrelic_logging_prefix}-${var.region}-logs-function-app"
+  function_app_name  = "newrelic-${var.newrelic_logging_prefix}-${var.region}-logs-function-app"
   function_app_shape = "GENERIC_X86"
   client_ttl         = 30
 
   # Function Constants
-  function_name        = "${var.newrelic_logging_prefix}-${var.region}-logs-function"
+  function_name        = "newrelic-${var.newrelic_logging_prefix}-${var.region}-logs-function"
   memory_in_mbs        = "128"
-  image_version_latest = "latest" # todo: to modify post version decision
-  image_url            = "${var.region}.ocir.io/idfmbxeaoavl/newrelic-log-container/log-forwarder:${local.image_version_latest}" #todo: change once prod ocir is ready
 
   # Connector Hub Constants
-  batch_size_in_kbs = 100 # todo: change batch size
+  batch_size_in_kbs = 6000
   batch_time_in_sec = 60
 }

--- a/examples/modules/cloud-integrations/oci/logs-integration/locals.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/locals.tf
@@ -30,5 +30,5 @@ locals {
   function_name                 = "newrelic-${var.newrelic_logging_identifier}-${var.region}-logs-function-${local.terraform_suffix}"
   function_memory_in_mbs        = "128"
   time_out_in_seconds           = 300
-  image_url                     = "${var.region}/idfmbxeaoavl/newrelic-log-container/log-forwarder:${var.image_version}"
+  image_url                     = "${var.region}/idptojlonu4e/newrelic-logs-integration/oci-log-forwarder:${var.image_version}"
 }

--- a/examples/modules/cloud-integrations/oci/logs-integration/main.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/main.tf
@@ -16,11 +16,12 @@ resource "oci_functions_application" "logging_function_app" {
 
 # --- Function Resources ---
 resource "oci_functions_function" "logging_function" {
-  application_id  = oci_functions_application.logging_function_app.id
-  display_name    = local.function_name
-  memory_in_mbs   = local.memory_in_mbs
-  freeform_tags   = local.freeform_tags
-  image           = var.image_url
+  application_id     = oci_functions_application.logging_function_app.id
+  display_name       = local.function_name
+  memory_in_mbs      = local.function_memory_in_mbs
+  timeout_in_seconds = local.time_out_in_seconds
+  freeform_tags      = local.freeform_tags
+  image              = local.image_url
 }
 
 # --- Service Connector Hub - Routes logs to New Relic function ---
@@ -47,8 +48,8 @@ resource "oci_sch_service_connector" "nr_logging_service_connector" {
 
   target {
     kind              = "functions"
-    batch_size_in_kbs = local.batch_size_in_kbs
-    batch_time_in_sec = local.batch_time_in_sec
+    batch_size_in_kbs = var.batch_size_in_kbs
+    batch_time_in_sec = var.batch_time_in_sec
     compartment_id    = var.compartment_ocid
     function_id       = oci_functions_function.logging_function.id
   }

--- a/examples/modules/cloud-integrations/oci/logs-integration/main.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/main.tf
@@ -1,0 +1,76 @@
+locals {
+  freeform_tags = {
+    newrelic-terraform = "true"
+  }
+
+  # Function App Constants
+  function_app_name  = "${var.newrelic_logging_prefix}-${var.region}-logs-function-app"
+  function_app_shape = "GENERIC_X86"
+  client_ttl         = 30
+
+  # Function Constants
+  function_name        = "${var.newrelic_logging_prefix}-${var.region}-logs-function"
+  memory_in_mbs        = "128"
+  image_version_latest = "latest"
+  image_url            = "${var.region}.ocir.io/idfmbxeaoavl/newrelic-log-container/log-forwarder:${local.image_version_latest}" #todo: change once prod ocir is ready
+
+  # Connector Hub Constants
+  batch_size_in_kbs = 100 # todo: change batch size
+  batch_time_in_sec = 60
+}
+
+# --- Function App Resources ---
+resource "oci_functions_application" "logging_function_app" {
+  compartment_id = var.compartment_ocid
+  config = {
+    "VAULT_REGION"      = var.region
+    "DEBUG_ENABLED"     = var.debug_enabled
+    "NEW_RELIC_REGION"  = var.new_relic_region
+    "SECRET_OCID"       = var.secret_ocid
+    "CLIENT_TTL"        = local.client_ttl
+  }
+  display_name               = local.function_app_name
+  freeform_tags              = local.freeform_tags
+  shape                      = local.function_app_shape
+  subnet_ids                 = [var.function_subnet_id]
+}
+
+# --- Function Resources ---
+resource "oci_functions_function" "logging_function" {
+  application_id  = oci_functions_application.logging_function_app.id
+  display_name    = local.function_name
+  memory_in_mbs   = local.memory_in_mbs
+  freeform_tags   = local.freeform_tags
+  image           = local.image_url
+}
+
+# --- Service Connector Hub - Routes logs to New Relic function ---
+resource "oci_sch_service_connector" "nr_logging_service_connector" {
+  for_each = {
+    for connector in jsondecode(var.connector_hub_details) : connector.display_name => connector
+  }
+
+  compartment_id = var.compartment_ocid
+  display_name   = each.value.display_name
+  description    = each.value.description
+  freeform_tags  = local.freeform_tags
+
+  source {
+    kind = "logging"
+    dynamic "log_sources" {
+      for_each = each.value.log_sources
+      content {
+        compartment_id = log_sources.value.compartment_id
+        log_group_id   = log_sources.value.log_group_id
+      }
+    }
+  }
+
+  target {
+    kind              = "functions"
+    batch_size_in_kbs = local.batch_size_in_kbs
+    batch_time_in_sec = local.batch_time_in_sec
+    compartment_id    = var.compartment_ocid
+    function_id       = oci_functions_function.logging_function.id
+  }
+}

--- a/examples/modules/cloud-integrations/oci/logs-integration/main.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/main.tf
@@ -20,14 +20,14 @@ resource "oci_functions_function" "logging_function" {
   display_name    = local.function_name
   memory_in_mbs   = local.memory_in_mbs
   freeform_tags   = local.freeform_tags
-  image           = local.image_url
+  image           = var.image_url
 }
 
 # --- Service Connector Hub - Routes logs to New Relic function ---
 resource "oci_sch_service_connector" "nr_logging_service_connector" {
-  for_each = {
+  for_each = var.connector_hub_details != null ? {
     for connector in jsondecode(var.connector_hub_details) : connector.display_name => connector
-  }
+  } : {}
 
   compartment_id = var.compartment_ocid
   display_name   = each.value.display_name

--- a/examples/modules/cloud-integrations/oci/logs-integration/main.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/main.tf
@@ -1,24 +1,3 @@
-locals {
-  freeform_tags = {
-    newrelic-terraform = "true"
-  }
-
-  # Function App Constants
-  function_app_name  = "${var.newrelic_logging_prefix}-${var.region}-logs-function-app"
-  function_app_shape = "GENERIC_X86"
-  client_ttl         = 30
-
-  # Function Constants
-  function_name        = "${var.newrelic_logging_prefix}-${var.region}-logs-function"
-  memory_in_mbs        = "128"
-  image_version_latest = "latest"
-  image_url            = "${var.region}.ocir.io/idfmbxeaoavl/newrelic-log-container/log-forwarder:${local.image_version_latest}" #todo: change once prod ocir is ready
-
-  # Connector Hub Constants
-  batch_size_in_kbs = 100 # todo: change batch size
-  batch_time_in_sec = 60
-}
-
 # --- Function App Resources ---
 resource "oci_functions_application" "logging_function_app" {
   compartment_id = var.compartment_ocid

--- a/examples/modules/cloud-integrations/oci/logs-integration/main.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/main.tf
@@ -11,7 +11,7 @@ resource "oci_functions_application" "logging_function_app" {
   display_name               = local.function_app_name
   freeform_tags              = local.freeform_tags
   shape                      = local.function_app_shape
-  subnet_ids                 = [var.function_subnet_id]
+  subnet_ids                 = [var.create_vcn ? module.vcn[0].subnet_id[local.subnet] : var.function_subnet_id]
 }
 
 # --- Function Resources ---

--- a/examples/modules/cloud-integrations/oci/logs-integration/providers.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/providers.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.2.0"
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "7.12.0"
+    }
+  }
+}
+
+provider "oci" {
+  alias        = "home"
+  tenancy_ocid = var.tenancy_ocid
+  region       = var.region
+}

--- a/examples/modules/cloud-integrations/oci/logs-integration/variables.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/variables.tf
@@ -20,6 +20,12 @@ variable "newrelic_logging_prefix" {
 }
 
 # VCN variables
+variable "create_vcn" {
+  type        = bool
+  default     = true
+  description = "Variable to create virtual network for the setup. True by default"
+}
+
 variable "function_subnet_id" {
   type        = string
   description = "The OCID of the subnet to be used for the function app. If create_vcn is set to true, that will take precedence"

--- a/examples/modules/cloud-integrations/oci/logs-integration/variables.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/variables.tf
@@ -35,9 +35,15 @@ variable "function_subnet_id" {
 variable "connector_hub_details" {
   type        = string
   description = "JSON formatted string for the service connectors to be created. See README for details and example"
+  default     = null
 }
 
 # New Relic Function variables
+variable "image_url" {
+  type = string
+  description = "The URL of the Docker image for the New Relic function."
+}
+
 variable "debug_enabled" {
   type        = string
   default     = "FALSE"

--- a/examples/modules/cloud-integrations/oci/logs-integration/variables.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/variables.tf
@@ -1,0 +1,50 @@
+# OCI variables
+variable "tenancy_ocid" {
+  type        = string
+  description = "OCI tenant OCID, more details can be found at https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#five"
+}
+
+variable "compartment_ocid" {
+  type        = string
+  description = "The OCID of the compartment where resources will be created. Do not modify."
+}
+
+variable "region" {
+  type        = string
+  description = "The name of the OCI region where these resources will be deployed."
+}
+
+variable "newrelic_logging_prefix" {
+  type        = string
+  description = "The prefix for naming all the logging resources in this module."
+}
+
+# VCN variables
+variable "function_subnet_id" {
+  type        = string
+  description = "The OCID of the subnet to be used for the function app. If create_vcn is set to true, that will take precedence"
+}
+
+# Connector Hub Variables
+variable "connector_hub_details" {
+  type        = string
+  description = "JSON formatted string for the service connectors to be created. See README for details and example"
+}
+
+# New Relic Function variables
+variable "debug_enabled" {
+  type        = string
+  default     = "FALSE"
+  description = "Enable debug mode."
+}
+
+variable "new_relic_region" {
+  type        = string
+  default     = "US"
+  description = "New Relic Region. US or EU"
+}
+
+variable "secret_ocid" {
+  type        = string
+  description = "OCI Vault Secret OCID that contains the New Relic License Key."
+}

--- a/examples/modules/cloud-integrations/oci/logs-integration/variables.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/variables.tf
@@ -6,7 +6,7 @@ variable "tenancy_ocid" {
 
 variable "compartment_ocid" {
   type        = string
-  description = "The OCID of the compartment where resources will be created. Do not modify."
+  description = "The OCID of the compartment where resources will be created. Use the compartment OCID already created as part of Policy Setup module."
 }
 
 variable "region" {
@@ -14,9 +14,10 @@ variable "region" {
   description = "The name of the OCI region where these resources will be deployed."
 }
 
-variable "newrelic_logging_prefix" {
+variable "newrelic_logging_identifier" {
   type        = string
-  description = "The prefix for naming all the logging resources in this module."
+  description = "A unique label or name identifier for all resources in this deployment. Leave it blank if not needed."
+  default = ""
 }
 
 # VCN variables
@@ -38,10 +39,22 @@ variable "connector_hub_details" {
   default     = null
 }
 
+variable "batch_size_in_kbs" {
+  type = number
+  description = "The maximum size of the batch of events to process. Maximum is 6000 KB."
+  default = 6000
+}
+
+variable "batch_time_in_sec" {
+  type = number
+  description = "The maximum amount of time to wait before processing a batch of events. Maximum is 300 seconds."
+  default = 60
+}
+
 # New Relic Function variables
-variable "image_url" {
+variable "image_version" {
   type = string
-  description = "The URL of the Docker image for the New Relic function."
+  description = "The version of the Docker image for the New Relic function for the region."
 }
 
 variable "debug_enabled" {
@@ -58,5 +71,5 @@ variable "new_relic_region" {
 
 variable "secret_ocid" {
   type        = string
-  description = "OCI Vault Secret OCID that contains the New Relic License Key."
+  description = "OCI Vault Secret OCID that contains the New Relic License Key. Use the secret OCID already created as part of Policy Setup module."
 }

--- a/examples/modules/cloud-integrations/oci/logs-integration/variables.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/variables.tf
@@ -17,7 +17,7 @@ variable "region" {
 variable "newrelic_logging_identifier" {
   type        = string
   description = "A unique label or name identifier for all resources in this deployment. Leave it blank if not needed."
-  default = ""
+  default = "logs"
 }
 
 # VCN variables
@@ -55,6 +55,7 @@ variable "batch_time_in_sec" {
 variable "image_version" {
   type = string
   description = "The version of the Docker image for the New Relic function for the region."
+  default = "latest"
 }
 
 variable "debug_enabled" {

--- a/examples/modules/cloud-integrations/oci/logs-integration/vcn.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/vcn.tf
@@ -5,14 +5,14 @@ module "vcn" {
   compartment_id           = var.compartment_ocid
   defined_tags             = {}
   freeform_tags            = local.freeform_tags
-  vcn_cidrs                = ["10.0.0.0/16"]
-  vcn_dns_label            = "nrfunction"
+  vcn_cidrs                = [local.vcn_cidr_block]
+  vcn_dns_label            = local.vcn_dns_label
   vcn_name                 = local.vcn_name
   lockdown_default_seclist = false
   subnets = {
     private = {
-      cidr_block = "10.0.0.0/16"
-      type       = "private"
+      cidr_block = local.subnet_cidr_block
+      type       = local.subnet_type
       name       = local.subnet
     }
   }
@@ -40,7 +40,7 @@ resource "oci_core_default_route_table" "default_internet_route" {
   manage_default_resource_id = data.oci_core_route_tables.default_vcn_route_table[0].route_tables[0].id
   count = var.create_vcn ? 1 : 0
   route_rules {
-    destination       = "0.0.0.0/0"
+    destination       = local.internet_destination
     destination_type  = "CIDR_BLOCK"
     network_entity_id = module.vcn[0].internet_gateway_id
     description       = "Route to Internet Gateway for New Relic metrics"

--- a/examples/modules/cloud-integrations/oci/logs-integration/vcn.tf
+++ b/examples/modules/cloud-integrations/oci/logs-integration/vcn.tf
@@ -1,0 +1,68 @@
+module "vcn" {
+  source                   = "oracle-terraform-modules/vcn/oci"
+  version                  = "3.6.0"
+  count                    = var.create_vcn ? 1 : 0
+  compartment_id           = var.compartment_ocid
+  defined_tags             = {}
+  freeform_tags            = local.freeform_tags
+  vcn_cidrs                = ["10.0.0.0/16"]
+  vcn_dns_label            = "nrfunction"
+  vcn_name                 = local.vcn_name
+  lockdown_default_seclist = false
+  subnets = {
+    private = {
+      cidr_block = "10.0.0.0/16"
+      type       = "private"
+      name       = local.subnet
+    }
+  }
+  create_nat_gateway           = true
+  nat_gateway_display_name     = local.nat_gateway
+  create_service_gateway       = true
+  service_gateway_display_name = local.service_gateway
+  create_internet_gateway      = true
+  internet_gateway_display_name = local.internet_gateway
+}
+
+data "oci_core_route_tables" "default_vcn_route_table" {
+  count = var.create_vcn ? 1 : 0
+  compartment_id = var.compartment_ocid
+  vcn_id         = module.vcn[0].vcn_id
+
+  filter {
+    name   = "display_name"
+    values = ["Default Route Table for ${local.vcn_name}"]
+    regex  = false
+  }
+}
+
+resource "oci_core_default_route_table" "default_internet_route" {
+  manage_default_resource_id = data.oci_core_route_tables.default_vcn_route_table[0].route_tables[0].id
+  count = var.create_vcn ? 1 : 0
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = module.vcn[0].internet_gateway_id
+    description       = "Route to Internet Gateway for New Relic metrics"
+  }
+}
+
+output "vcn_network_details" {
+  depends_on  = [module.vcn]
+  description = "Output of the created network infra"
+  value = var.create_vcn && length(module.vcn) > 0 ? {
+    vcn_id             = module.vcn[0].vcn_id
+    nat_gateway_id     = module.vcn[0].nat_gateway_id
+    nat_route_id       = module.vcn[0].nat_route_id
+    service_gateway_id = module.vcn[0].service_gateway_id
+    sgw_route_id       = module.vcn[0].sgw_route_id
+    subnet_id          = module.vcn[0].subnet_id[local.subnet]
+  } : {
+    vcn_id             = ""
+    nat_gateway_id     = ""
+    nat_route_id       = ""
+    service_gateway_id = ""
+    sgw_route_id       = ""
+    subnet_id          = var.function_subnet_id
+  }
+}

--- a/website/docs/guides/cloud_integrations_guide.html.markdown
+++ b/website/docs/guides/cloud_integrations_guide.html.markdown
@@ -310,7 +310,7 @@ module "oci_logs_integration" {
   
   # network components
   create_vcn = true # set to false to reuse existing VCN/subnet created from metrics module
-  function_subnet_id = module.oci_metrics_integration.function_subnet_id # ignored when create_vcn = true
+  function_subnet_id = module.oci_metrics_integration.vcn_network_details.subnet_id # ignored when create_vcn = true
   
   # function application environment variables configuration
   debug_enabled = "FALSE"
@@ -326,7 +326,8 @@ Key variables:
 
 - network components:
   - `create_vcn`: set to false to reuse existing VCN/subnet created from metrics module. 
-  - `function_subnet_id`: subnet OCID for the function to be created in. Ignored if create_vcn is true. 
+  - `function_subnet_id`: subnet OCID for the function to be created in. Ignored if create_vcn is true.
+> If you want to use an existing private subnet, make sure it has required route rules and gateways with internet and all OCI services access. 
 - function application environment variables configuration:
   - `debug_enabled`: Boolean to enable or disable function debug logs.
   - `new_relic_region`: The New Relic region (US or EU).

--- a/website/docs/guides/cloud_integrations_guide.html.markdown
+++ b/website/docs/guides/cloud_integrations_guide.html.markdown
@@ -312,6 +312,7 @@ module "oci_logs_integration" {
   # connector hub configuration (Optional)
   # provide empty string ("") or null to skip log export
   connector_hub_details = "[{\"display_name\":\"newrelic-logs-connector\",\"description\":\"Service connector for logs from compartment A to New Relic\",\"log_sources\":[{\"compartment_id\":\"ocid1.tenancy.oc1..***\",\"log_group_id\":\"ocid1.loggroup.oc1.iad.***\"}]}]"
+  image_url = "iad.ocir.io/newrelic/functions/newrelic-oci-logs-integration:latest" # latest image for the region of your choice
 }
 ```
 

--- a/website/docs/guides/cloud_integrations_guide.html.markdown
+++ b/website/docs/guides/cloud_integrations_guide.html.markdown
@@ -303,21 +303,23 @@ module "oci_logs_integration" {
   region = "us-ashburn-1"
   
   # new relic logging prefix
-  newrelic_logging_identifier = "newrelic-logs"
+  newrelic_logging_identifier = "logs"
   
   # network components
   create_vcn = true # set to false to reuse existing VCN/subnet created from metrics module
   function_subnet_id = module.oci_metrics_integration.vcn_network_details.subnet_id # ignored when create_vcn = true
   
   # function application environment variables configuration
+  image_version = "latest" # latest image version for the logging function
   debug_enabled = "FALSE"
   new_relic_region = "US"
   secret_ocid = module.oci_policy_setup.ingest_vault_ocid
   
   # connector hub configuration (Optional)
-  # provide empty string ("") or null to skip log export
+  # Don't add the following variables if you want to skip log export.
   connector_hub_details = "[{\"display_name\":\"newrelic-logs-connector\",\"description\":\"Service connector for logs from compartment A to New Relic\",\"log_sources\":[{\"compartment_id\":\"ocid1.tenancy.oc1..***\",\"log_group_id\":\"ocid1.loggroup.oc1.iad.***\"}]}]"
-  image_version = "latest" # latest image version for the logging function
+  batch_size_in_kbs = 6000 # max payload size in KBs (default 6000)
+  batch_time_in_sec = 60 # max wait time in seconds before sending batch (default 60)
 }
 ```
 

--- a/website/docs/guides/cloud_integrations_guide.html.markdown
+++ b/website/docs/guides/cloud_integrations_guide.html.markdown
@@ -309,7 +309,8 @@ module "oci_logs_integration" {
   new_relic_region = "US"
   secret_ocid = module.oci_policy_setup.ingest_vault_ocid
   
-  # connector hub configuration
+  # connector hub configuration (Optional)
+  # provide empty string ("") or null to skip log export
   connector_hub_details = "[{\"display_name\":\"newrelic-logs-connector\",\"description\":\"Service connector for logs from compartment A to New Relic\",\"log_sources\":[{\"compartment_id\":\"ocid1.tenancy.oc1..***\",\"log_group_id\":\"ocid1.loggroup.oc1.iad.***\"}]}]"
 }
 ```

--- a/website/docs/guides/cloud_integrations_guide.html.markdown
+++ b/website/docs/guides/cloud_integrations_guide.html.markdown
@@ -309,7 +309,8 @@ module "oci_logs_integration" {
   newrelic_logging_prefix = "newrelic-logs"
   
   # network components
-  function_subnet_id = module.oci_policy_setup.function_subnet_id
+  create_vcn = true # set to false to reuse existing VCN/subnet created from metrics module
+  function_subnet_id = module.oci_metrics_integration.function_subnet_id # ignored when create_vcn = true
   
   # function application environment variables configuration
   debug_enabled = "FALSE"
@@ -323,6 +324,9 @@ module "oci_logs_integration" {
 
 Key variables:
 
+- network components:
+  - `create_vcn`: set to false to reuse existing VCN/subnet created from metrics module. 
+  - `function_subnet_id`: subnet OCID for the function to be created in. Ignored if create_vcn is true. 
 - function application environment variables configuration:
   - `debug_enabled`: Boolean to enable or disable function debug logs.
   - `new_relic_region`: The New Relic region (US or EU).

--- a/website/docs/guides/cloud_integrations_guide.html.markdown
+++ b/website/docs/guides/cloud_integrations_guide.html.markdown
@@ -303,7 +303,7 @@ module "oci_logs_integration" {
   region = "us-ashburn-1"
   
   # new relic logging prefix
-  newrelic_logging_prefix = "newrelic-logs"
+  newrelic_logging_identifier = "newrelic-logs"
   
   # network components
   create_vcn = true # set to false to reuse existing VCN/subnet created from metrics module
@@ -317,7 +317,7 @@ module "oci_logs_integration" {
   # connector hub configuration (Optional)
   # provide empty string ("") or null to skip log export
   connector_hub_details = "[{\"display_name\":\"newrelic-logs-connector\",\"description\":\"Service connector for logs from compartment A to New Relic\",\"log_sources\":[{\"compartment_id\":\"ocid1.tenancy.oc1..***\",\"log_group_id\":\"ocid1.loggroup.oc1.iad.***\"}]}]"
-  image_url = "iad.ocir.io/newrelic/functions/newrelic-oci-logs-integration:latest" # latest image for the region of your choice
+  image_version = "latest" # latest image version for the logging function
 }
 ```
 


### PR DESCRIPTION
# Description

This PR adds an example for OCI Logging Integrations with New Relic. It does not create any new resource or data type, but just an example code to integrate oracle logging with new relic. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.

## How to test this change?

1. terrafrom init
2. terraform plan
3. terraform apply